### PR TITLE
fix: config file

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -148,17 +148,20 @@ class JobbergateAgentCharm(CharmBase):
         for setting, is_required in settings_to_map.items():
             value = self.model.config.get(setting, unset)
 
-            # If any config value is not yet available, defer
-            if value is unset and is_required:
+            if value is unset and not is_required:
+                # Not set, not required, just continue
+                continue
+            elif value is unset and is_required:
+                # Is unset but required, defer
                 event.defer()
                 return
-            else:
-                env_context[setting] = value
 
-                mapped_key = setting.replace("-", "_")
-                store_value = getattr(self.stored, mapped_key, unset)
-                if store_value != value:
-                    setattr(self.stored, mapped_key, value)
+            env_context[setting] = value
+
+            mapped_key = setting.replace("-", "_")
+            store_value = getattr(self.stored, mapped_key, unset)
+            if store_value != value:
+                setattr(self.stored, mapped_key, value)
 
         self.jobbergate_agent_ops.configure_env_defaults(
             config_context=env_context,


### PR DESCRIPTION
Testing on the cluster, we've seen the following line on the config file:
```
JOBBERGATE_AGENT_SLURMRESTD_JWT_KEY_STRING=<object object at 0x7fb88243c460>
```

Clearly something that should not be there, with a reference for a Python object.

To patch the issue, fields that are unset and not required should be skipped.