### PR TITLE
[ASP-4245] Add new configuration to control if the submission files should be written to the submit dir

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to charm-jobbergate-agent.
 
 Unreleased
 ----------
+- Added configuration to control if the submission files should be written to the submit directory
 
 1.0.0 - 2023-09-07
 ------------------ 

--- a/config.yaml
+++ b/config.yaml
@@ -71,6 +71,11 @@ options:
     default: slurm
     description: |
       The default username to use for requests to the Slurm REST API
+  write-submission-files:
+    type: boolean
+    default: true
+    description: |
+      Define if the job script files will be written to the submit directory
 
   # Tasks
   task-jobs-interval-seconds:

--- a/src/charm.py
+++ b/src/charm.py
@@ -124,6 +124,7 @@ class JobbergateAgentCharm(CharmBase):
             "x-slurm-user-name": True,
             "task-jobs-interval-seconds": False,
             "task-garbage-collection-hour": False,
+            "write-submission-files": True,
         }
 
         if not self.model.config.get(

--- a/src/jobbergate_agent_ops.py
+++ b/src/jobbergate_agent_ops.py
@@ -113,7 +113,7 @@ class JobbergateAgentOps:
             "venv",
             self._VENV_DIR.as_posix(),
         ]
-        logger.debug(f"## Creating virtualenv: {create_venv_cmd }")
+        logger.debug(f"## Creating virtualenv: {create_venv_cmd}")
         subprocess.call(create_venv_cmd, env=dict())
         logger.debug("## jobbergate-agent virtualenv created")
 


### PR DESCRIPTION
#### What
Add new configuration `write-submission-files` to control whether the agent should download the job script file.
If it's set to `True`, the behaviour is exactly as before.
If it's set to `False`, the submission will be rejected if there are supporting files. If there aren't, the job script will be passed to the `slurmrestd` API as the payload and won't be downloaded to the submit dir.

#### Why
The submission was failing when the agent didn't have permission to write to the submit dir.

`Task`: https://jira.scania.com/browse/ASP-4245

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
