### PR TITLE
fix: trigger install addon on charm install

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to charm-jobbergate-agent.
 
 Unreleased
 ----------
+- Added trigger to install jobbergate-agent's addons on charm install
 
 1.0.1 - 2023-11-29
 ------------------ 

--- a/src/charm.py
+++ b/src/charm.py
@@ -53,6 +53,10 @@ class JobbergateAgentCharm(CharmBase):
 
         try:
             self.jobbergate_agent_ops.install()
+            if self.model.config.get("plugins-install"):
+                self.jobbergate_agent_ops._install_jobbergate_addon(
+                    self.model.config["plugins-install"]
+                )
             self.stored.installed = True
         except Exception as e:
             logger.error(f"## Error installing agent: {e}")


### PR DESCRIPTION
We've identified that `install_jobbergate_addon` was not triggered when the charm was installed, just on config update. This PR fixes the issue.